### PR TITLE
Fix dynamic queryset in VideoForm

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -1,11 +1,19 @@
 from django import forms
 from .models import Video, Tema
 class VideoForm(forms.ModelForm):
+    # La consulta de `Tema` debe realizarse al instanciar el formulario para
+    # reflejar los temas creados después de que se cargó el módulo.
     temas = forms.ModelMultipleChoiceField(
-        queryset=Tema.objects.all(),
+        queryset=Tema.objects.none(),
         widget=forms.SelectMultiple(attrs={'class': 'select2', 'multiple': 'multiple'}),
         required=False
     )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Al inicializar el formulario, actualizamos el queryset para que
+        # incluya todos los temas disponibles en la base de datos.
+        self.fields['temas'].queryset = Tema.objects.all()
 
     class Meta:
         model = Video  


### PR DESCRIPTION
## Summary
- ensure VideoForm loads available `Tema` options dynamically

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_683f7c3db78c8326823b85e6fa1857a5