### PR TITLE
Add Font Awesome link

### DIFF
--- a/core/Templates/base.html
+++ b/core/Templates/base.html
@@ -6,6 +6,7 @@
   <meta charset="UTF-8">
   <title>{% block title %}Sistema{% endblock %}</title>
   <link href="{% static 'css/style.css' %}" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
   {% block extra_css %}{% endblock %}
 </head>
 <body>


### PR DESCRIPTION
## Summary
- include Font Awesome stylesheet in `base.html`

## Testing
- `python manage.py runserver 0.0.0.0:8000` *(fails: ModuleNotFoundError: No module named 'spacy')*

------
https://chatgpt.com/codex/tasks/task_e_68447f1f083483268b900762ced7e9aa