### PR TITLE
Fix sidebar link to translator

### DIFF
--- a/core/Templates/vista_funcionario.html
+++ b/core/Templates/vista_funcionario.html
@@ -17,7 +17,7 @@
   <!-- Sidebar -->
   <div class="sidebar" id="sidebar">
     <a href="{% url 'vista_admin' %}">Menú Principal</a>
-    <a href="{% url 'listar_usuarios' %}">Traducir a LSCH</a>
+    <a href="{% url 'traductor' %}">Traducir a LSCH</a>
     <a href="{% url 'listar_videos' %}">Realizar encuesta</a>
     <a href="{% url 'logout' %}">Cerrar sesión</a>
   </div>


### PR DESCRIPTION
## Summary
- update 'Traducir a LSCH' link in funcionario sidebar so it targets the translator view

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844829d6bc883268f33aba133b9d533