### PR TITLE
Implement video logging in ver_encuesta

### DIFF
--- a/core/services/informe_service.py
+++ b/core/services/informe_service.py
@@ -1,0 +1,17 @@
+"""Service to register viewed videos for reporting purposes."""
+from pathlib import Path
+from typing import Optional
+
+_LOG_FILE = Path(__file__).resolve().parent.parent / "informes_videos.log"
+
+
+def registrar_video(video: Optional[object]) -> None:
+    """Append basic info about a played video to the log file."""
+    if not video:
+        return
+    try:
+        with open(_LOG_FILE, "a", encoding="utf-8") as f:
+            f.write(f"{video.id},{video.nombre}\n")
+    except Exception:
+        # Silently ignore logging errors
+        pass

--- a/core/views.py
+++ b/core/views.py
@@ -15,6 +15,7 @@ from django.contrib.auth.hashers import make_password
 from .services.spacy_translator import  translate_to_lsch
 from .services.spacy_extractor import extract_keywords_spacy
 from .services.synonym_service import get_synonyms
+from .services.informe_service import registrar_video
 
 
 def es_admin(user):
@@ -397,7 +398,15 @@ def ver_encuesta(request, tramite_id):
     """
     tramite = get_object_or_404(Tramite, id=tramite_id)
     encuesta = tramite.encuesta  # Puede ser None si aún no se creó
-    playlist = tramite.playlist if (encuesta and tramite.playlist) else []  # Solo mostrar playlist si la encuesta existe
+    playlist = (
+        tramite.playlist if (encuesta and tramite.playlist) else []
+    )  # Solo mostrar playlist si la encuesta existe
+
+    if playlist:
+        for item in playlist:
+            video = Video.objects.filter(nombre=item.get("titulo")).first()
+            if video:
+                registrar_video(video)
 
     return render(request, "usuario/ver_encuesta.html", {
         "tramite": tramite,


### PR DESCRIPTION
## Summary
- log reproduced videos via informe_service
- hook up registrar_video into ver_encuesta view

## Testing
- `python manage.py check` *(fails: numpy.dtype size changed, may indicate binary incompatibility)*

------
https://chatgpt.com/codex/tasks/task_e_684498f61e4c8326b616b61dfd78cb0e