### PR TITLE
Update admin links to reports page

### DIFF
--- a/core/Templates/admin_usuario/listar.html
+++ b/core/Templates/admin_usuario/listar.html
@@ -17,7 +17,7 @@
     <a href="{% url 'vista_admin' %}">Menu Principal</a>
     <a href="{% url 'listar_usuarios' %}">Administrar usuarios</a>
     <a href="{% url 'listar_videos' %}">Videos LSCH</a>
-    <a href="{% url 'listar_videos' %}">Generar reporte</a>
+    <a href="{% url 'informes' %}">Generar reporte</a>
     <a href="{% url 'logout' %}">Cerrar sesión</a>
   </div>
 

--- a/core/Templates/admin_usuario/listar_video.html
+++ b/core/Templates/admin_usuario/listar_video.html
@@ -16,7 +16,7 @@
     <a href="{% url 'vista_admin' %}">Menu Principal</a>
     <a href="{% url 'listar_usuarios' %}">Administrar usuarios</a>
     <a href="{% url 'listar_videos' %}">Videos LSCH</a>
-    <a href="{% url 'listar_videos' %}">Generar reporte</a>
+    <a href="{% url 'informes' %}">Generar reporte</a>
     <a href="{% url 'logout' %}">Cerrar sesión</a>
   </div>
 

--- a/core/Templates/base.html
+++ b/core/Templates/base.html
@@ -15,6 +15,7 @@
       <nav>
         {% if user.is_superuser or user.es_administrador %}
           <a href="{% url 'vista_admin' %}">Panel Admin</a>
+          <a href="{% url 'informes' %}">Informes</a>
         {% endif %}
         {% if user.es_funcionario %}
           <a href="{% url 'vista_funcionario' %}">Panel Funcionario</a>

--- a/core/Templates/vista_admin.html
+++ b/core/Templates/vista_admin.html
@@ -14,7 +14,7 @@
     <a href="{% url 'vista_admin' %}">Menu Principal</a>
     <a href="{% url 'listar_usuarios' %}">Administrar usuarios</a>
     <a href="{% url 'listar_videos' %}">Videos LSCH</a>
-    <a href="{% url 'listar_videos' %}">Generar reporte</a>
+    <a href="{% url 'informes' %}">Generar reporte</a>
     <a href="{% url 'logout' %}">Cerrar sesión</a>
   </div>
 


### PR DESCRIPTION
## Summary
- add link to Informes in base navbar for administrators
- point "Generar reporte" sidebar links to Informes

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684498f6aa0083269938f66ec07c9f63