### PR TITLE
Add informes shortcut card

### DIFF
--- a/core/Templates/vista_funcionario.html
+++ b/core/Templates/vista_funcionario.html
@@ -38,6 +38,10 @@
         <div class="icon"><i class="fa fa-film"></i></div>
         <div class="label">Realizar encuesta</div>
       </a>
+      <a href="{% url 'informes' %}" class="shortcut-card">
+        <div class="icon"><i class="fa fa-bar-chart"></i></div>
+        <div class="label">Informes</div>
+      </a>
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add an Informes card in the funcionario shortcuts

## Testing
- `python manage.py test` *(fails: numpy / spaCy binary incompatibility)*

------
https://chatgpt.com/codex/tasks/task_e_684498faa4c48326bd4ca79f25891903