### PR TITLE
Switch to xhtml2pdf for PDF reports

### DIFF
--- a/TLSCH/urls.py
+++ b/TLSCH/urls.py
@@ -36,4 +36,5 @@ urlpatterns = [
     path('tramite/<int:tramite_id>/crear_encuesta/', login_required(views.crear_encuesta), name='crear_encuesta'),
 
     path('informes/', views.informe_list, name='informes'),
+    path('informes/pdf/', views.generar_pdf, name='generar_pdf'),
 ]

--- a/core/Templates/informe_pdf.html
+++ b/core/Templates/informe_pdf.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<style>
+    table { width: 100%; border-collapse: collapse; }
+    th, td { border: 1px solid #ddd; padding: 6px; font-size: 12px; }
+    th { background: #f2f2f2; }
+</style>
+</head>
+<body>
+<h1>Informe</h1>
+<h2>Diario</h2>
+<table>
+    <thead>
+        <tr><th>Tema</th><th>Fecha</th><th>Total</th></tr>
+    </thead>
+    <tbody>
+    {% for row in datos.diario %}
+        <tr><td>{{ row.tema }}</td><td>{{ row.fecha }}</td><td>{{ row.total }}</td></tr>
+    {% empty %}
+        <tr><td colspan="3">No hay datos</td></tr>
+    {% endfor %}
+    </tbody>
+</table>
+<h2>Semanal</h2>
+<table>
+    <thead>
+        <tr><th>Tema</th><th>Semana</th><th>Total</th></tr>
+    </thead>
+    <tbody>
+    {% for row in datos.semanal %}
+        <tr><td>{{ row.tema }}</td><td>{{ row.semana }}</td><td>{{ row.total }}</td></tr>
+    {% empty %}
+        <tr><td colspan="3">No hay datos</td></tr>
+    {% endfor %}
+    </tbody>
+</table>
+<h2>Mensual</h2>
+<table>
+    <thead>
+        <tr><th>Tema</th><th>Mes</th><th>Total</th></tr>
+    </thead>
+    <tbody>
+    {% for row in datos.mensual %}
+        <tr><td>{{ row.tema }}</td><td>{{ row.mes }}</td><td>{{ row.total }}</td></tr>
+    {% empty %}
+        <tr><td colspan="3">No hay datos</td></tr>
+    {% endfor %}
+    </tbody>
+</table>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- replace WeasyPrint with xhtml2pdf support
- add `render_to_pdf` helper
- add `generar_pdf` view and URL
- include new `informe_pdf.html` template

## Testing
- `pip install -q -r requirements.txt`
- `python manage.py check` *(fails: numpy binary incompatibility)*

------
https://chatgpt.com/codex/tasks/task_e_6845930d79cc83268237d23b8e75d67e